### PR TITLE
auth: 회원가입/로그인 플로우 정리 및 스키마·UX 개선

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -14,14 +14,39 @@ export const authApi = {
     verifyEmailCode: (email: string, code: string) => 
         api.post('/v1/users/register/email/verify', { email, code }),
     registerAppUser: (data: { email: string, password: string }) =>
-        api.post('/v1/users/register/app', data),
+        api.post('/v1/users/register/password', data),
     checkNicknameDuplicate: (nickname: string) => 
         api.get('/v1/users/register/check/nickname', { params: { nickname }}),
-    registerFinal: (gender: 'MALE' | 'FEMALE', formData: FormData) =>
-        api.post(`/v1/users/register/final=${gender}`, formData, {
-            headers: { 'Content-Type': 'multipart/form-data' }
-        }),
-    registerFinalKaKao: (payload: {
-        code: string; nickname: string; themes: string[]; gender: 'MALE' | 'FEMALE'; birthYear: string; referralNickname?: string;
+
+    registerFinal: (
+        payload: {
+            email: string;
+            nickname: string;
+            themes: string[];
+            gender: 'MALE' | 'FEMALE';
+            birthYear: string;
+            referrerNickname: string;
+        }, profileFile?: File
+    ) => {
+            const fd = new FormData();
+
+            const dataBlob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
+            fd.append('data', dataBlob);
+
+            // profile 있을 때만,
+            if (profileFile) fd.append('profile', profileFile, profileFile.name);
+
+            return api.post('/v1/users/register/final', fd)
+            
+        },
+
+    registerFinalKaKao: (
+        payload: {
+        code: string; 
+        nickname: string; 
+        themes: string[]; 
+        gender: 'MALE' | 'FEMALE'; 
+        birthYear: string; 
+        referrerNickname: string;
     }) => api.post('/v1/users/kakao/final-register', payload),
 }

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,22 +1,38 @@
-import axios from "axios";
+import axios, { AxiosHeaders } from "axios";
 
 const api = axios.create({
     baseURL: '/api',
     withCredentials: true,
-    headers: {
-        'Content-Type': 'application/json'
-    },
+    // headers: {
+    //     'Content-Type': 'application/json'
+    // },
     timeout: 0, // 요청 제한시간
 });
 
 // 요청 인터셉터
-api.interceptors.request.use(config => {
+api.interceptors.request.use((config) => {
+    const isForm = typeof FormData !== 'undefined' && config.data instanceof FormData;
+    const header = config.headers as AxiosHeaders | Record<string, any> | undefined;
+
+    if(isForm) {
+        if((header as any)?.delete) {
+            (header as AxiosHeaders).delete('Content-Type');
+        }
+        if(header) {
+            delete (header as any)['Content-Type'];
+            delete (header as any)['content-type'];
+        }
+    } else {
+        if ((header as any)?.set) (header as AxiosHeaders).set("Content-Type", "application/json");
+        else (header as any)["Content-Type"] = "application/json";
+    }
+
     return config;
 }, error => Promise.reject(error));
 
 // 응답 인터셉터
 api.interceptors.response.use(res => res, error => {
-    if (error.res?.status == 401) {
+    if (error.response?.status == 401) {
         // 로그인 만료
     }
     return Promise.reject(error);

--- a/src/components/auth/register/normal/steps/GenderStep.tsx
+++ b/src/components/auth/register/normal/steps/GenderStep.tsx
@@ -14,8 +14,8 @@ const GenderStep = ({
 }: GenderStepProps) => {
 
     const options = [
-        { label: '남자', value: 'male'},
-        { label: '여자', value: 'female'},
+        { label: '남자', value: 'MALE'},
+        { label: '여자', value: 'FEMALE'},
     ]
 
     const { state } = useRegister();

--- a/src/components/auth/register/normal/stepsRender/renderProfileSettingStep.tsx
+++ b/src/components/auth/register/normal/stepsRender/renderProfileSettingStep.tsx
@@ -65,7 +65,7 @@ export function renderProfileSettingStep(
 
     const handleChangeReferral = (value: string) => {
         dispatch({ type: "SET_REFERRAL_CODE", payload: value });
-        dispatch({ type: "SET_REFERRAL_ERROR", payload: value ? '' : '추천인을 입력해주세요. (ex.제주데이)' })
+        dispatch({ type: "SET_REFERRAL_ERROR", payload: value.trim() ? '' : '추천인을 입력해주세요. (ex.제주데이)' })
     }
 
     return(

--- a/src/components/commons/Forms/ProfileSettingForm.tsx
+++ b/src/components/commons/Forms/ProfileSettingForm.tsx
@@ -49,6 +49,7 @@ const ProfileSettingForm = ({
                 type="text"
                 placeholder="최대 8자까지 가능해요."
                 value={nickname}
+                maxLength={8}
                 onChange={(e) => onChangeNickname(e.target.value)}
                 onBlur={onBlurNickname}
                 validation={validation}
@@ -71,6 +72,7 @@ const ProfileSettingForm = ({
                     <InputTextField 
                         type="text"
                         value={referralCode || ''}
+                        maxLength={8}
                         onChange={(e) => onChangeReferral?.(e.target.value)}
                         validation={referralError ? 'negative' : 'normal'}
                         message={referralError}

--- a/src/components/commons/Forms/interestForm.tsx
+++ b/src/components/commons/Forms/interestForm.tsx
@@ -4,7 +4,7 @@ import type { interestsFormProps } from "./types";
 import { AlertBox, InterestFormWrapper, ThemeItems, ThemeWrapper } from "./form.styles";
 import AlertIcon from "src/assets/Alert.svg";
 
-const interestList = ["데이트", "힐링", "반려동물", "사진 명소", "가족 여행", "자연", "한달 살이", "나홀로 여행", "맛집 탐방", "액티비티", "액티비티", "액티비티"];
+const interestList = ["데이트", "힐링", "반려동물", "사진 명소", "가족 여행", "자연", "한달 살이", "나홀로 여행", "맛집 탐방", "액티비티", "액티", "비티"];
 
 const InterestForm = ({ themes = [] , selected = [], onSelect }: interestsFormProps) => {
     const handleClick = (item: string) => {
@@ -19,7 +19,7 @@ const InterestForm = ({ themes = [] , selected = [], onSelect }: interestsFormPr
             <AuthCaption style={{ margin: 0 }}>선택한 테마를 참고하여 추천해드릴게요!</AuthCaption>
             <ThemeWrapper>
                 {activeThemes.map((item) => (
-                    <ThemeItems key={item} isActive={selected.includes(item)} onClick={() => handleClick(item)}>
+                    <ThemeItems key={item} type='button'  isActive={selected.includes(item)} onClick={() => handleClick(item)}>
                         {item}
                     </ThemeItems>
                 ))}

--- a/src/components/commons/Header/LogoHeader.tsx
+++ b/src/components/commons/Header/LogoHeader.tsx
@@ -1,4 +1,4 @@
-import Logo from '../../../assets/react.svg'
+import Logo from '../../../assets/Logo.svg'
 import styled from '@emotion/styled';
 
 const LogoWrapper = styled.div`
@@ -8,7 +8,7 @@ const LogoWrapper = styled.div`
 const LogoHeader = () => {
     return (
         <LogoWrapper>
-            <img src={Logo} alt='하루제주' />
+            <img src={Logo} alt='하루제주' style={{ width: "40px"}} />
         </LogoWrapper>
     )
 };

--- a/src/components/splash/PermissionCard.tsx
+++ b/src/components/splash/PermissionCard.tsx
@@ -1,4 +1,3 @@
-import LogoHeader from "../commons/Header/LogoHeader";
 import { Guide, PermissionLeft, PermissionList, PermissionListBox, PermissionWrapper } from "./splash.style";
 import { ButtonWrapper } from "../auth/login/login.style";
 import Notification from '../../assets/Alarm.svg';
@@ -21,7 +20,6 @@ interface PermissionCardProps {
 const PermissionCard = ({ onAllow }: PermissionCardProps) => {
     return (
         <>
-            <LogoHeader />
             <PermissionWrapper>
                 <Guide>
                     앱 사용 권한을 위해 <br />

--- a/src/components/splash/RegisterChoiceButton.tsx
+++ b/src/components/splash/RegisterChoiceButton.tsx
@@ -1,5 +1,5 @@
 import { EmailRegisterBtn, KaKaoBtn, RegisterButtonWrapper, SplashLogoWrapper, Welcome } from "./splash.style";
-import Logo from '../../assets/react.svg';
+import Logo from '../../assets/Logo.svg';
 import KaKao from '../../assets/kakao_login_large_wide.png';
 
 interface RegisterChoiceButtonProps {

--- a/src/components/splash/splash.style.ts
+++ b/src/components/splash/splash.style.ts
@@ -49,6 +49,7 @@ export const GoToLogin = styled.div`
 export const PermissionWrapper = styled.div`
     display: flex;
     flex-direction: column;
+    margin-top: 96px;
     gap: 46px;
     padding: 0 20px;
 `;

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -26,7 +26,7 @@ const LoginPage = () => {
                 return;
             };
 
-            navigate('/')
+            navigate('/main')
 
 
         } catch (error:any) {

--- a/src/pages/auth/register/normal/RegisterFlow.tsx
+++ b/src/pages/auth/register/normal/RegisterFlow.tsx
@@ -8,14 +8,29 @@ import { useRegister } from "src/context/AuthContext"
 const RegisterFlow = () => {
     const { state, dispatch } = useRegister();
     const [step, setStep] = useState(0);
+    const [submitting, setSubmitting] = useState(false);
     const navigate = useNavigate();
 
     const totalSteps = state.kakaoEmail ? 3 : 5;
+
+    const buildProfileFile = async (): Promise<File | undefined> => {
+        try {
+            const blob = await fetch(state.imageUrl).then(r => r.blob());
+            return new File([blob], 'profile.png', {type: blob.type});
+        } catch(e) {
+            console.warn("프로필 파일 변환 실패(무시하고 진행)", e);
+        }
+
+        return undefined;
+    };
 
     const goNext = async () => {
         const isLastStep = step === totalSteps - 1;
 
         if (isLastStep) {
+            if(submitting) return;
+            setSubmitting(true);
+
             try {
                 // 카카오 
                 if (state.kakaoEmail) {
@@ -25,57 +40,42 @@ const RegisterFlow = () => {
                         themes: state.themes,
                         gender: state.gender as 'MALE' | 'FEMALE',
                         birthYear: state.birthYear,
-                        referralNickname: state.referralCode || undefined,
+                        referrerNickname: state.referralCode,
                     }; 
     
                     const res = await authApi.registerFinalKaKao(kakaoPayload);
-    
-                    if (res.data.success) {
-                        navigate('/');
+                    if (res.data?.success) {
+                        navigate('/main');
+                        return;
                     } else {
                         console.error('회원가입 실패:', res.data?.message);
-                    }
-                } else {
-                    // 일반
-                    const formData = new FormData();
-    
-                    formData.append(
-                        'data', new Blob(
-                            [JSON.stringify({
-                                email: state.email,
-                                password: state.password,
-                                nickname: state.nickname,
-                                birthYear: state.birthYear,
-                                themes: state.themes,
-                                language: 'KO',
-                                platform: 'APP'
-                            })],
-                            { type: 'application/json' }
-                        )
-                    );
-    
-                    // 프로필 이미지 첨부
-                    if (state.imageUrl && !state.imageUrl.includes('default_profile.svg')) {
-                        const file = await fetch(state.imageUrl)
-                            .then((res) => res.blob())
-                            .then(
-                                (blob) => new File([blob], 'profile.png', { type: blob.type })
-                            );
-                        formData.append('profile', file);
-                    }
-    
-                    const genderQuery = state.gender || 'MALE';
-                    const res = await authApi.registerFinal(genderQuery as 'MALE' | 'FEMALE', formData);
-    
-                    if(res.data.success) {
-                        navigate('/');
-                    } else {
-                        console.error('회원가입 실패:', res.data?.message);
-                    }
+                        return;
+                    };
                 }
-    
+
+                // 일반
+                const profileFile = await buildProfileFile();
+                const payload = {
+                    email: state.email,
+                    nickname: state.nickname.trim(),
+                    themes: state.themes,
+                    gender: state.gender as 'MALE' | 'FEMALE',
+                    birthYear: state.birthYear,
+                    referrerNickname: state.referralCode,
+                }
+
+                const res = await authApi.registerFinal(payload, profileFile);
+                if(res.data?.success) {
+                    navigate('/main');
+                    return;
+                } else {
+                    console.error('회원가입 실패:', res.data?.message);
+                    return;
+                }    
             } catch(err) {
                 console.error('회원가입 에러:', err);
+            } finally {
+                setSubmitting(false);
             }
         }
         
@@ -85,7 +85,7 @@ const RegisterFlow = () => {
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        goNext(); // 마지막 단계에서만 처리
+        await goNext(); // 마지막 단계에서만 처리
     }
 
     return (

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -11,4 +11,4 @@ export const validateBirthYear = (value: string): string => {
     }
 
     return '';
-}
+};

--- a/src/utils/validation/passwordSchema.ts
+++ b/src/utils/validation/passwordSchema.ts
@@ -4,7 +4,9 @@ export const passwordSchema = z
     .string()
     .min(8, "8자리 이상 입력해주세요.")
     .max(12, "12자리 이하로 입력해주세요.")
-    .regex(/[^A-Za-z0-9]/, "특수문자를 포함해야합니다.");
+    .regex(/^[A-Za-z0-9!_@-]+$/, "영문/숫자/!, _, @, -만 사용할 수 있어요.")
+    .regex(/[!_@-]/, "특수문자(!, _, @, -)를 1개 이상 포함해주세요.")
+    .regex(/[A-Za-z0-9]/, "영문 또는 숫자를 1개 이상 포함해주세요.")
 
 export const passwordConfirmSchema = z
     .object({


### PR DESCRIPTION
회원가입 스키마 재점검에 따른 타입/폼 데이터 정리, 요청 헤더 처리 개선, 잘못된 값/유효성 이슈 수정, 버튼/로고/네비게이션 등 UX 디테일 보완을 하였습니다.

1. API & 타입/폼데이터
> 회원가입 스키마 재확인 후 타입 정의 보정 및 Blob/FormData 구성 수정
> intance 헤더 조건부 설정: FormData 사용시 Content-Type 자동 반영되도록 수동 지정 제거

2. 폼 검증
> gender 잘못된 value 수정 (ex. male → MALE)
> 추천인 조건 추가 (trim)
> zod 기반 비밀번호 검증 스키마 수정 (특문/영문/숫자)

3. UI/UX
> themes 선택 버튼에 type='button'지정 (submit 방지)
> 헤더/스플래시 로고 수정

4. 네비게이션
> 회원가입/로그인 navigate 경로 수정


이후 보완 이슈 : 카카오 OAuth 로직 재검증, 로그인 상태에서 register/login 진입 차단